### PR TITLE
docs(network egress): add first version

### DIFF
--- a/docs/labs/network-egress.md
+++ b/docs/labs/network-egress.md
@@ -1,0 +1,12 @@
+# Skills Network Labs Egress Firewall
+
+By default, learners are not allowed to access external resources from within Skills Network Labs.
+
+This is an unfortunate necessity due to the potential for abuse.
+
+To enable access to external resources for learners taking your lab, you will need to add an allowed destination to your course or guided project.
+
+From your course or guided project page, select the "Advanced" tab and scroll down to "Add access to external resources". From here you can add a URL and justification for why this domain needs to be accessible.
+
+
+After the domain is added, the destination should be accessible within 15 minutes.


### PR DESCRIPTION
We're trying to link to this article from labs right now (every time we block a learner's egress), I guess I forgot to create it